### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: 3.8
+version: '3.8'
 services:
   l4d2:
     image: left4devops/l4d2


### PR DESCRIPTION
fix for `validating docker-compose.yml: version must be a string`